### PR TITLE
1 run ubysseyca and thothubysseyca as isolated apps on docker swarm vm

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create a GitHub App token
         id: app-token
-      - uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -1,10 +1,9 @@
-name: Deploy to production
+name: Create thoth-frontend docker image
 
 on:
   release:
     types: [published]
-  push:
-    branches: [1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm]
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -3,7 +3,8 @@ name: Deploy to production
 on:
   release:
     types: [published]
-
+  push:
+    branches: [1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -22,32 +22,51 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Log in to the Container registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=v{{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v4
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      #     tags: |
+      #       type=schedule
+      #       type=ref,event=branch
+      #       type=ref,event=pr
+      #       type=semver,pattern=v{{version}}
+      #       type=semver,pattern={{major}}.{{minor}}
+      #       type=semver,pattern={{major}}
+      #       type=sha
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
+      # - name: Build and push Docker image
+      #   id: push
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
         with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ubyssey
+          repositories: thoth
+
+      - name: Trigger deploy-production workflow in thoth
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
+            -d '{"ref":"1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm"}'

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -23,39 +23,43 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@v4
-      #   with:
-      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      #     tags: |
-      #       type=schedule
-      #       type=ref,event=branch
-      #       type=ref,event=pr
-      #       type=semver,pattern=v{{version}}
-      #       type=semver,pattern={{major}}.{{minor}}
-      #       type=semver,pattern={{major}}
-      #       type=sha
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
-      # - name: Build and push Docker image
-      #   id: push
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
       - name: Create a GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -76,4 +76,4 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
-            -d '{"ref":"1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm","inputs":{"skip_build":"true"}}'
+            -d '{"ref":"main","inputs":{"skip_build":"true"}}'

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -77,4 +77,4 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
-            -d '{"ref":"1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm"}'
+            -d '{"ref":"1-run-ubysseyca-and-thothubysseyca-as-isolated-apps-on-docker-swarm-vm","inputs":{"skip_build":"true"}}'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and deploying the `thoth-frontend` Docker image. The main improvements include setting up Docker Buildx for better build performance, adding build cache support, and automating the triggering of a production deployment in the `thoth` repository via a GitHub App token.

**Workflow improvements:**

* Renamed the workflow from "Deploy to production" to "Create thoth-frontend docker image" for clarity.
* Added a step to set up Docker Buildx, enabling advanced Docker build features.
* Configured Docker build caching with `cache-from` and `cache-to` options to speed up subsequent builds.

**Deployment automation:**

* Added steps to create a GitHub App token using the `actions/create-github-app-token` action, allowing secure authentication.
* Automated the triggering of the `deploy-production` workflow in the `ubyssey/thoth` repository after the image is built, using the generated GitHub App token for authentication.