### PR TITLE
updated to push frontend tag

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -76,4 +76,4 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
-            -d '{"ref":"main","inputs":{"skip_build":"true"}}'
+            -d '{"ref":"main","inputs":{"skip_build":"true","frontend_tag":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
This pull request makes a targeted update to the deployment workflow by passing an additional input parameter to the production deployment trigger. The new parameter, `frontend_tag`, is set to the current branch or tag name, allowing the deployment process to reference the correct frontend version.

Deployment workflow update:

* [`.github/workflows/build-container-image.yml`](diffhunk://#diff-3a3de14c42b1fc18b5d13e3adc277811aba3f08e133e24c777363bbb9afd5e9dL79-R79): Modified the API call that triggers the production deployment workflow to include a `frontend_tag` input, set to the value of `${{ github.ref_name }}`.