### PR TITLE
1 run ubysseyca and thothubysseyca as isolated apps on docker swarm vm

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -76,4 +76,4 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
-            -d '{"ref":"main","inputs":{"skip_build":"true","frontend_tag":"${{ github.ref_name }}"}}'
+            -d '{"ref":"main","inputs":{"skip_backend_build":"true","frontend_version":"${{ github.ref_name }}"}}'

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -76,4 +76,4 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ubyssey/thoth/actions/workflows/deploy-production.yml/dispatches \
-            -d '{"ref":"main","inputs":{"skip_backend_build":"true","frontend_version":"${{ github.ref_name }}"}}'
+            -d '{"ref":"main","inputs":{"skip_backend_build":"true","frontend_build_success":"true","frontend_version":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
This pull request updates the deployment workflow trigger to better reflect the current build process and provide more granular control over deployment inputs.

**Workflow dispatch input changes:**

* Updated the API call in `.github/workflows/build-container-image.yml` to use `skip_backend_build`, `frontend_build_success`, and `frontend_version` as workflow inputs instead of the previous `skip_build` and `frontend_tag` parameters. This allows for more precise control and clearer communication between build and deployment workflows.